### PR TITLE
docs: remove incorrect Twitter link on Eiman Jahangir's team entry

### DIFF
--- a/MoonDAO/docs/About/Team.md
+++ b/MoonDAO/docs/About/Team.md
@@ -66,7 +66,6 @@ Treasury signers are responsible for executing transactions on the [MoonDAO Trea
 **Wallet Address:** 0xb1d4c1B9c8DA3191Fdb515Fa7AdeC3D41D014F4f
 
 ## Dr. Eiman Jahangir
-**Socials:** https://twitter.com/yang_zhuxiang
 **Discord:** @eimanjahangir
 **Bio:** MoonDAO's second astronaut.
 **Wallet Address:** 0xe2d3aC725E6FFE2b28a9ED83bedAaf6672f2C801


### PR DESCRIPTION
## What
Dr. Eiman Jahangir's entry on the Team page listed `twitter.com/yang_zhuxiang` as his Socials link — an unrelated handle (copy-paste error). Removed the incorrect link.

No verified replacement handle was available, so the line was removed rather than guessed. If someone has his correct social link, it can be added back.

Part of a documentation audit, split into focused PRs for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)